### PR TITLE
Adds tests, fixes npm usage, a bit of cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 components
 build
+coverage
+node_modules

--- a/index.js
+++ b/index.js
@@ -1,17 +1,22 @@
-var ie = require('ie');
-
-function with_query_strings(request) {
-    request._query = [Date.now().toString()]
-    return request;
+var ie
+try {
+  ie = require('ie')
+} catch (e) {
+  ie = require('component-ie')
 }
 
-module.exports = function (request) {
-	request.set('X-Requested-With', 'XMLHttpRequest');
-	request.set('Cache-Control', 'no-cache,no-store,must-revalidate,max-age=-1');
+function with_query_strings (request) {
+  request._query = [Date.now().toString()]
+  return request
+}
 
-    if (ie) {
-        with_query_strings(request);
-    }
+module.exports = function _superagentNoCache (request) {
+  request.set('X-Requested-With', 'XMLHttpRequest')
+  request.set('Cache-Control', 'no-cache,no-store,must-revalidate,max-age=-1')
 
-	return request;
-};
+  if (ie) {
+    with_query_strings(request)
+  }
+
+  return request
+}

--- a/index.js
+++ b/index.js
@@ -10,11 +10,11 @@ function with_query_strings (request) {
   return request
 }
 
-module.exports = function _superagentNoCache (request) {
+module.exports = function _superagentNoCache (request, mockIE) {
   request.set('X-Requested-With', 'XMLHttpRequest')
   request.set('Cache-Control', 'no-cache,no-store,must-revalidate,max-age=-1')
 
-  if (ie) {
+  if (ie || mockIE) {
     with_query_strings(request)
   }
 

--- a/package.json
+++ b/package.json
@@ -3,14 +3,39 @@
   "repo": "johntron/superagent-no-cache",
   "description": "Plugin for visionmedia/superagent that adds headers to all requests that prevents caching",
   "version": "0.0.1",
-  "keywords": [],
-  "dependencies": {
-      "component/ie": "0.0.1"
+  "keywords": [
+    "superagent",
+    "cache",
+    "request",
+    "AJAX"
+  ],
+  "author": "John Syrinek <john.syrinek@gmail.com>",
+  "contributors": [
+    "Trent Oswald <trentoswald@therebelrobot.com> [@therebelrobot] (http://therebelrobot.com)"
+  ],
+  "bugs": {
+    "url": "https://github.com/johntron/superagent-no-cache/issues"
   },
-  "development": {},
+  "homepage": "https://github.com/johntron/superagent-no-cache",
   "license": "MIT",
   "main": "index.js",
-  "scripts": [
-    "index.js"
-  ]
+  "scripts": {
+    "test": "./node_modules/standard/bin/cmd.js && ./node_modules/istanbul/lib/cli.js cover _mocha --"
+  },
+  "standard": {
+    "ignore": [
+      "**/test/**"
+    ]
+  },
+  "dependencies": {
+    "component-ie": "^1.0.0",
+    "component/ie": "0.0.1"
+  },
+  "devDependencies": {
+    "chai": "^2.3.0",
+    "istanbul": "^0.3.13",
+    "mocha": "^2.2.4",
+    "mock-browser": "^0.90.33",
+    "standard": "^3.7.2"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superagent-no-cache",
-  "repo": "johntron/superagent-no-cache",
+  "repository": "https://github.com/johntron/superagent-no-cache.git",
   "description": "Plugin for visionmedia/superagent that adds headers to all requests that prevents caching",
   "version": "0.0.1",
   "keywords": [
@@ -20,7 +20,7 @@
   "license": "MIT",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/standard/bin/cmd.js && ./node_modules/istanbul/lib/cli.js cover _mocha --"
+    "test": "./node_modules/standard/bin/cmd.js; ./node_modules/istanbul/lib/cli.js cover _mocha --"
   },
   "standard": {
     "ignore": [
@@ -28,8 +28,7 @@
     ]
   },
   "dependencies": {
-    "component-ie": "^1.0.0",
-    "component/ie": "0.0.1"
+    "component-ie": "^1.0.0"
   },
   "devDependencies": {
     "chai": "^2.3.0",

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,3 @@
+--recursive
+--growl
+--reporter=nyan

--- a/test/superagent-no-cache.test.js
+++ b/test/superagent-no-cache.test.js
@@ -1,0 +1,18 @@
+var expect = require('chai').expect
+
+var MockBrowser = require('mock-browser').mocks.MockBrowser
+var mock = new MockBrowser()
+
+document = mock.getDocument()
+
+var nocache = require('../index')
+
+/* Definitions for JS Standard */
+/* global describe, it */
+
+describe('superagent-no-cache', function () {
+  it('should return a function', function (done) {
+    expect(nocache).to.be.a('function')
+    done()
+  })
+})

--- a/test/superagent-no-cache.test.js
+++ b/test/superagent-no-cache.test.js
@@ -10,9 +10,83 @@ var nocache = require('../index')
 /* Definitions for JS Standard */
 /* global describe, it */
 
-describe('superagent-no-cache', function () {
-  it('should return a function', function (done) {
-    expect(nocache).to.be.a('function')
+describe('superagent-no-cache', _suiteMain)
+
+/* Suites */
+
+function _suiteMain () {
+  it('should return a function', _specFunctionCheck)
+  it('should require the "set" subfunction', _specSetCheck)
+  it('should run the "set" subfunction, assigning the appropriate values', _specSetRun)
+  it('should add an additional query for IE browsers', _specIE)
+}
+
+/* Specs */
+
+function _specFunctionCheck (done) {
+  expect(nocache).to.be.a('function')
+  done()
+}
+
+function _specSetCheck (done) {
+  var request = {};
+  try{
+    var results = nocache(request)
+    expect(true)
+      .to.be(false)
+    done('This should have been an error')
+  }
+  catch(error){
+    expect(error)
+      .to.be.an('object')
+    expect(error.toString())
+      .to.equal('TypeError: undefined is not a function')
     done()
-  })
-})
+  }
+}
+function _specSetRun (done) {
+  var request = {
+    set:_mockSet,
+    data:{}
+  };
+  var results = nocache(request)
+
+  expect(results.data['X-Requested-With'])
+    .to.be.a('string')
+  expect(results.data['X-Requested-With'])
+    .to.equal('XMLHttpRequest')
+
+  expect(results.data['Cache-Control'])
+    .to.be.a('string')
+  expect(results.data['Cache-Control'])
+    .to.equal('no-cache,no-store,must-revalidate,max-age=-1')
+
+  expect(results._query)
+    .to.be.an('undefined')
+
+  done()
+}
+function _specIE (done) {
+  var request = {
+    set:_mockSet,
+    data:{}
+  };
+  var results = nocache(request, true)
+  expect(results.data['X-Requested-With'])
+    .to.equal('XMLHttpRequest')
+  expect(results.data['Cache-Control'])
+    .to.equal('no-cache,no-store,must-revalidate,max-age=-1')
+  expect(results._query)
+    .to.be.an('array')
+  expect(results._query[0])
+    .to.be.a('string')
+  expect(results._query[0].substring(0, results._query[0].length - 1))
+    .to.equal(Date.now().toString().substring(0, results._query[0].length - 1))
+  done()
+}
+
+/* Mocks */
+
+function _mockSet (arg1, arg2) {
+  this.data[arg1] = arg2
+}


### PR DESCRIPTION
I cleaned up the `package.json`, added to `.gitignore`, normalized tabbing in `index.js`, made it [feross/standard](https://github.com/feross/standard) compliant (that in particular isn't completely necessary, I could use [semistandard](https://github.com/Flet/semistandard) if the no-semicolons is a dealbreaker). Also made sure the function attached to `module.exports` was properly named for stack traces.

If this lands, I'll make another PR with updated docs.

References to issues https://github.com/johntron/superagent-no-cache/issues/3 (package.json cleanup), https://github.com/johntron/superagent-no-cache/issues/4 (testing), https://github.com/johntron/superagent-no-cache/issues/6 ('ie' module issue)

Commit Comments:

> commit: 61ede08956960a1cc2269281a7f555a3ec830846
> 
> There was an initial issue with requiring the 'ie' module,
> which with component works properly, but is published
> under a different name in npm ('component-ie'). Added
> a try/catch to the head of the library to ensure
> proper inclusion.
> 
> Testing is done via mocha, tests are located in the
> `test/` folder, and can be run by using `npm test`. This
> will chack all non-test scripts with feross/standard syntax
> tester, then run mocha through istanbul, which  not only
> runs tests, but also gives coverage reporting. You can access
> the coverage report in `coverage/lcov-report/index.html`
> 
> To ensure that the feross/standard passed without issue, I made
> minor alterations to the styling of `index.js` (space before function
> parentheses, removed semicolons), as well as added a function name
> to the main `module.exports` function, as it was anonymous previously.

and

> commit: 3c7283ef471ab8cb0364e164673ef34694375f99
> 
> I built out four major tests:
> 
> * to see if nocache is returned as a function
> * to see if it is requiring require.set()
> * to see if it uses request.set() to set the appropriate values
> * to see if the appropriate query is added in IE
> 
> I added an additional parameter to the main _superagentNoCache()
> function, to allow for the mocking of IE, since component/ie uses
> cray <!-- if gt IE --!> for it's browser check, and I have
> absolutely no idea how to mock that. Shouldn't cause any conflicts.