### PR TITLE
Set request headers for IE caching

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,8 @@ function with_query_strings (request) {
 
 module.exports = function _superagentNoCache (request, mockIE) {
   request.set('X-Requested-With', 'XMLHttpRequest')
-  request.set('Cache-Control', 'no-cache,no-store,must-revalidate,max-age=-1')
+  request.set('Expires', '-1')
+  request.set('Cache-Control', 'no-cache,no-store,must-revalidate,max-age=-1,private')
 
   if (ie || mockIE) {
     with_query_strings(request)


### PR DESCRIPTION
I was having an issue in IE9/10 where is it appeared that requests were still being cached.  This solved the problem.