### PR TITLE
Fixed overriding of querystring in internet explorer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ components
 build
 coverage
 node_modules
+.idea/

--- a/Readme.md
+++ b/Readme.md
@@ -29,7 +29,11 @@ request.get('/url')
 
 ## Contributing
 
-To come soon...
+To run the tests install mocha and run:
+
+```bash
+$ mocha test/superagent-no-cache.test.js
+```
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ try {
 function with_query_strings (request) {
   var timestamp = Date.now().toString()
   if (request._query !== undefined && request._query[0]) {
-    request._query[0] += '&buster=' + timestamp
+    request._query[0] += '&' + timestamp
   } else {
     request._query = [timestamp]
   }

--- a/index.js
+++ b/index.js
@@ -6,7 +6,13 @@ try {
 }
 
 function with_query_strings (request) {
-  request._query = [Date.now().toString()]
+  var timestamp = Date.now().toString()
+  if (request._query !== undefined && request._query[0]) {
+    request._query[0] += '&buster=' + timestamp
+  } else {
+    request._query = [timestamp]
+  }
+
   return request
 }
 

--- a/test/superagent-no-cache.test.js
+++ b/test/superagent-no-cache.test.js
@@ -101,7 +101,7 @@ function _specIEExistingQuery (done) {
   expect(results._query[0])
       .to.be.a('string')
   expect(results._query[0])
-      .to.match(/^param=123&buster=[0-9].*$/)
+      .to.match(/^param=123&[0-9].*$/)
   done();
 }
 

--- a/test/superagent-no-cache.test.js
+++ b/test/superagent-no-cache.test.js
@@ -19,6 +19,7 @@ function _suiteMain () {
   it('should require the "set" subfunction', _specSetCheck)
   it('should run the "set" subfunction, assigning the appropriate values', _specSetRun)
   it('should add an additional query for IE browsers', _specIE)
+  it('should add an additional param to an existing query string for IE browsers', _specIEExistingQuery)
 }
 
 /* Specs */
@@ -40,7 +41,7 @@ function _specSetCheck (done) {
     expect(error)
       .to.be.an('object')
     expect(error.toString())
-      .to.equal('TypeError: undefined is not a function')
+      .to.contain('TypeError')
     done()
   }
 }
@@ -59,7 +60,7 @@ function _specSetRun (done) {
   expect(results.data['Cache-Control'])
     .to.be.a('string')
   expect(results.data['Cache-Control'])
-    .to.equal('no-cache,no-store,must-revalidate,max-age=-1')
+    .to.equal('no-cache,no-store,must-revalidate,max-age=-1,private')
 
   expect(results._query)
     .to.be.an('undefined')
@@ -75,7 +76,7 @@ function _specIE (done) {
   expect(results.data['X-Requested-With'])
     .to.equal('XMLHttpRequest')
   expect(results.data['Cache-Control'])
-    .to.equal('no-cache,no-store,must-revalidate,max-age=-1')
+    .to.equal('no-cache,no-store,must-revalidate,max-age=-1,private')
   expect(results._query)
     .to.be.an('array')
   expect(results._query[0])
@@ -83,6 +84,25 @@ function _specIE (done) {
   expect(results._query[0].substring(0, results._query[0].length - 1))
     .to.equal(Date.now().toString().substring(0, results._query[0].length - 1))
   done()
+}
+function _specIEExistingQuery (done) {
+  var request = {
+    set:_mockSet,
+    _query: ['param=123'], // random query string
+    data:{}
+  };
+  var results = nocache(request, true);
+  expect(results.data['X-Requested-With'])
+      .to.equal('XMLHttpRequest')
+  expect(results.data['Cache-Control'])
+      .to.equal('no-cache,no-store,must-revalidate,max-age=-1,private')
+  expect(results._query)
+      .to.be.an('array')
+  expect(results._query[0])
+      .to.be.a('string')
+  expect(results._query[0])
+      .to.match(/^param=123&buster=[0-9].*$/)
+  done();
 }
 
 /* Mocks */


### PR DESCRIPTION
* Added Webstorm IDE directory to .gitignore
* Added check if querystring exists and then only append a cache buster
* Adjusted and also fixed tests (were not working)
* Added info about how to run tests to Readme.md